### PR TITLE
[UI][Tanks Complex] Only apply reload on relevant changes

### DIFF
--- a/projects/planner/src/app/plan/tanks-complex/tanks-complex.component.ts
+++ b/projects/planner/src/app/plan/tanks-complex/tanks-complex.component.ts
@@ -159,8 +159,16 @@ export class TanksComplexComponent extends Streamed implements OnInit {
         bound.startPressure = Number(values.tankStartPressure);
         bound.o2 = Number(values.tankO2);
         bound.he = Number(values.tankHe);
+        let updates: {[i: string]: number} = {
+            tankO2: bound.o2,
+            tankHe: bound.he,
+        }
+        const roundedTankSize = Precision.round(bound.size, 1);
+        if (bound.size !== Precision.round(bound.size, 1)){
+            updates.tankSize = Precision.round(bound.size, 1)
+        }
         // to enforce reload he and O2 fields in case the affected each other
-        this.reload(bound, index);
+        tankControl.patchValue(updates);
 
         this.dispatcher.sendTankChanged();
     }
@@ -185,7 +193,7 @@ export class TanksComplexComponent extends Streamed implements OnInit {
     private reload(bound: TankBound, index: number): void {
         const tankControl = this.tanksGroup.at(index);
         tankControl.patchValue({
-            tankSize: Precision.round(bound.size, 1), // because of HP100
+            tankSize: bound.size, // because of HP100
             tankWorkPressure: bound.workingPressure,
             tankStartPressure: bound.startPressure,
             tankO2: bound.o2,


### PR DESCRIPTION
## Summary
Typing in decimal values of the tank size can be difficult due to the values reloading and turning `11.` into `11`. This only applies a reload to the tank size if the rounding is necessary.

### Note
This does not fix the undesirable behavior on helium / oxygen percentages. I was unable to figure out where those adding up to 100 is enforced. 

## Testing
- [x] Passing unit tests
- [x] Played around with the component on my [instance](https://deco.marktai.com/?t=1-11.11-0-200-0.209-0&de=0-30-102-1,30-30-618-1&di=20,30&o=0,9,3,3,3,18,2,0.85,0.4,3,1.6,30,1.4,10,1,1,0,2,1,0,20,5&ao=1,0)