### PR TITLE
#85 Add planner deco stop distance 5m

### DIFF
--- a/projects/planner/src/app/shared/planner.service.spec.ts
+++ b/projects/planner/src/app/shared/planner.service.spec.ts
@@ -465,26 +465,22 @@ describe('PlannerService', () => {
         });
     });
 
-    describe('Deco stop distance is applied', () => {
-        xit('contains 5 m step in wayPoints and emergencyAscent', () => {
+describe('Deco stop distance is applied', () => {
+        it('contains 5 m stop interval when decoStopDistance = 5 m', () => {
+            depthsService.planDuration = 40;
 
-        optionsService.getOptions().decoStopDistance = 5;
-        planner.calculate(1);
+            optionsService.getOptions().decoStopDistance = 5;
+            planner.calculate(1);
 
-        const tol = 0.1;
+            const toIntervals = (depths: number[]) =>
+            depths.slice(1).map((d, i) => Math.abs(d - depths[i]))
+            .filter(interval => interval > 0 && interval <= 10);
 
-        const wayDeltas = dive.wayPoints
-        .map(p => p.endDepth)
-        .map((d, i, a) => i === 0 ? NaN : Math.abs(d - a[i - 1]))
-        .filter(Number.isFinite);
+            const wayStopIntervals  = toIntervals(dive.wayPoints.map(p => p.endDepth));
+            const emerStopIntervals = toIntervals(dive.emergencyAscent.map(p => p.endDepth));
 
-        const emerDeltas = dive.emergencyAscent
-        .map(p => p.endDepth)
-        .map((d, i, a) => i === 0 ? NaN : Math.abs(d - a[i - 1]))
-        .filter(Number.isFinite);
-
-        expect(wayDeltas.some(d => Math.abs(d - 5) <= tol)).toBeTrue();
-        expect(emerDeltas.some(d => Math.abs(d - 5) <= tol)).toBeTrue();
+        expect(wayStopIntervals.includes(5)).toBeTrue();
+        expect(emerStopIntervals.includes(5)).toBeTrue();
 
         });
     });

--- a/projects/planner/src/app/shared/planner.service.spec.ts
+++ b/projects/planner/src/app/shared/planner.service.spec.ts
@@ -464,4 +464,28 @@ describe('PlannerService', () => {
             expect(_(dive.events).some(e => e.isNoDeco)).toBeFalsy();
         });
     });
+
+    describe('Deco stop distance is applied', () => {
+        xit('contains 5 m step in wayPoints and emergencyAscent', () => {
+
+        optionsService.getOptions().decoStopDistance = 5;
+        planner.calculate(1);
+
+        const tol = 0.1;
+
+        const wayDeltas = dive.wayPoints
+        .map(p => p.endDepth)
+        .map((d, i, a) => i === 0 ? NaN : Math.abs(d - a[i - 1]))
+        .filter(Number.isFinite);
+
+        const emerDeltas = dive.emergencyAscent
+        .map(p => p.endDepth)
+        .map((d, i, a) => i === 0 ? NaN : Math.abs(d - a[i - 1]))
+        .filter(Number.isFinite);
+
+        expect(wayDeltas.some(d => Math.abs(d - 5) <= tol)).toBeTrue();
+        expect(emerDeltas.some(d => Math.abs(d - 5) <= tol)).toBeTrue();
+
+        });
+    });
 });

--- a/projects/planner/src/app/shared/planner.service.spec.ts
+++ b/projects/planner/src/app/shared/planner.service.spec.ts
@@ -466,22 +466,20 @@ describe('PlannerService', () => {
     });
 
 describe('Deco stop distance is applied', () => {
-        it('contains 5 m stop interval when decoStopDistance = 5 m', () => {
-            depthsService.planDuration = 40;
 
+        it('applies 5 m stop interval when decoStopDistance = 5 m', () => {
+            depthsService.planDuration = 40;
             optionsService.getOptions().decoStopDistance = 5;
             planner.calculate(1);
 
-            const toIntervals = (depths: number[]) =>
-            depths.slice(1).map((d, i) => Math.abs(d - depths[i]))
-            .filter(interval => interval > 0 && interval <= 10);
+            const wayDepths = dive.wayPoints.map(p => p.endDepth);
+            const emerDepths = dive.emergencyAscent.map(p => p.endDepth);
 
-            const wayStopIntervals  = toIntervals(dive.wayPoints.map(p => p.endDepth));
-            const emerStopIntervals = toIntervals(dive.emergencyAscent.map(p => p.endDepth));
+            const expectedWayDepths = [30, 30, 15, 15, 10, 10, 5, 5, 3, 3, 0];
+            const expectedEmerDepths = [30, 15, 15, 10, 10, 5, 5, 3, 3, 0];
 
-        expect(wayStopIntervals.includes(5)).toBeTrue();
-        expect(emerStopIntervals.includes(5)).toBeTrue();
-
+            expect(wayDepths).toEqual(expectedWayDepths);
+            expect(emerDepths).toEqual(expectedEmerDepths);
         });
     });
 });


### PR DESCRIPTION
Added a simplified test for applying a 5 m deco stop distance.  
The test verifies expected endDepth arrays for wayPoints and emergencyAscent